### PR TITLE
Support iso language codes and fail on invalid language

### DIFF
--- a/duckling/duckling.py
+++ b/duckling/duckling.py
@@ -93,7 +93,7 @@ class Duckling(object):
         Args:
             input_str: The input as string that has to be parsed.
             language: Optional parameter to specify language,
-                e.g. Duckling.ENGLISH.
+                e.g. Duckling.ENGLISH or supported ISO 639-1 Code (e.g. "en")
             dim_filter: Optional parameter to specify list of filters for
                 dimensions in Duckling.
             reference_time: Optional reference time for Duckling.
@@ -108,6 +108,7 @@ class Duckling(object):
         if self._is_loaded is False:
             raise RuntimeError(
                 'Please load the model first by calling load()')
+        language = Language.convert_to_duckling_language_id(language)
         duckling_parse = self.clojure.var("duckling.core", "parse")
         duckling_time = self.clojure.var("duckling.time.obj", "t")
         clojure_hashmap = self.clojure.var("clojure.core", "hash-map")

--- a/duckling/language.py
+++ b/duckling/language.py
@@ -20,3 +20,41 @@ class Language(object):
     UKRAINIAN = 'uk$core'
     VIETNAMESE = 'vi$core'
     CHINESE = 'zh$core'
+
+    SUPPORTED_LANGUAGES = [
+        ARABIC,
+        DANISH,
+        GERMAN,
+        ENGLISH,
+        SPANISH,
+        ESTONIAN,
+        FRENCH,
+        IRISH,
+        INDONESIAN,
+        ITALIAN,
+        JAPANESE,
+        KOREAN,
+        PORTUGUESE,
+        RUSSIAN,
+        UKRAINIAN,
+        VIETNAMESE,
+        CHINESE,
+    ]
+
+    @classmethod
+    def is_supported(cls, lang):
+        """Check if a language is supported by the current duckling version."""
+
+        return lang in cls.SUPPORTED_LANGUAGES
+
+    @classmethod
+    def convert_to_duckling_language_id(cls, lang):
+        """Ensure a language identifier has the correct duckling format and is supported."""
+
+        if lang is not None and cls.is_supported(lang):
+            return lang
+        elif lang is not None and cls.is_supported(lang + "$core"):   # Support ISO 639-1 Language Codes (e.g. "en")
+            return lang + "$core"
+        else:
+            raise ValueError("Unsupported language '{}'. Supported languages: {}".format(
+                lang, ", ".join(cls.SUPPORTED_LANGUAGES)))

--- a/duckling/language.py
+++ b/duckling/language.py
@@ -21,7 +21,7 @@ class Language(object):
     VIETNAMESE = 'vi$core'
     CHINESE = 'zh$core'
 
-    SUPPORTED_LANGUAGES = [
+    SUPPORTED_LANGUAGES = {
         ARABIC,
         DANISH,
         GERMAN,
@@ -39,7 +39,7 @@ class Language(object):
         UKRAINIAN,
         VIETNAMESE,
         CHINESE,
-    ]
+    }
 
     @classmethod
     def is_supported(cls, lang):

--- a/duckling/wrapper.py
+++ b/duckling/wrapper.py
@@ -13,7 +13,7 @@ class DucklingWrapper(object):
         parse_datetime: Optional attribute to specify if datetime string should
             be parsed with datetime.strptime(). Default is False.
         language: Optional attribute to specify language to be used with
-            Duckling. Default is Language.ENGLISH.
+            Duckling. Default is Language.ENGLISH. E.g. Duckling.GERMAN or supported ISO 639-1 Code (e.g. "de")
         minimum_heap_size: Optional attribute to set initial and minimum heap
             size. Default is 128m.
         maximum_heap_size: Optional attribute to set maximum heap size. Default
@@ -27,7 +27,7 @@ class DucklingWrapper(object):
                  minimum_heap_size='128m',
                  maximum_heap_size='2048m'):
         super(DucklingWrapper, self).__init__()
-        self.language = language
+        self.language = Language.convert_to_duckling_language_id(language)
         self.duckling = Duckling(
             jvm_started=jvm_started,
             parse_datetime=parse_datetime,


### PR DESCRIPTION
Proposed changes:
- fail if language is passed, which is not supported by underlying version of duckling
- accept iso language codes (e.g. `"en"`) as well as `"en$core"`