### PR TITLE
Add option to load specific languages instead of all

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Duckling(jvm_started=False, parse_datetime=False, minimum_heap_size='128m', maxi
             is 2048m.
     """
 
-duckling.load(self, languages=None):
+duckling.load(self, languages=[]):
         """Loads the Duckling corpus.
 
         Languages can be specified, defaults to all.

--- a/README.md
+++ b/README.md
@@ -209,8 +209,15 @@ Duckling(jvm_started=False, parse_datetime=False, minimum_heap_size='128m', maxi
             is 2048m.
     """
 
-duckling.load():
-        """Loads the Duckling corpus"""
+duckling.load(self, languages=None):
+        """Loads the Duckling corpus.
+
+        Languages can be specified, defaults to all.
+
+        Args:
+            languages: Optional parameter to specify languages,
+                e.g. [Duckling.ENGLISH, Duckling.FRENCH] or supported ISO 639-1 Codes (e.g. ["en", "fr"])
+        """
 
 duckling.parse(self, input_str, language=Language.ENGLISH, dim_filter=None, reference_time=''):
         """Parses datetime information out of string input.

--- a/duckling/duckling.py
+++ b/duckling/duckling.py
@@ -85,7 +85,7 @@ class Duckling(object):
 
         Args:
             languages: Optional parameter to specify languages,
-                e.g. [Duckling.ENGLISH, Duckling.FRENCH] or supported ISO 639-1 Codes (e.g. ["en", "fr])
+                e.g. [Duckling.ENGLISH, Duckling.FRENCH] or supported ISO 639-1 Codes (e.g. ["en", "fr"])
         """
         duckling_load = self.clojure.var("duckling.core", "load!")
 

--- a/duckling/duckling.py
+++ b/duckling/duckling.py
@@ -78,10 +78,24 @@ class Duckling(object):
                     jars.append(os.path.join(top, file_name))
         return os.pathsep.join(jars)
 
-    def load(self):
-        """Loads the Duckling corpus"""
+    def load(self, languages=None):
+        """Loads the Duckling corpus.
+
+        Languages can be specified, defaults to all.
+
+        Args:
+            languages: Optional parameter to specify languages,
+                e.g. a list of supported ISO 639-1 Codes (e.g. ["en"])
+        """
         duckling_load = self.clojure.var("duckling.core", "load!")
-        duckling_load.invoke()
+
+        # Duckling's load function expects ISO 639-1 Language Codes (e.g. "en")
+        if languages is not None and all(Language.is_supported(lang + "$core") for lang in languages):
+            languages = '{{:languages ("{}")}}'.format('" "'.join(languages))
+            duckling_load.invoke(self.clojure.read(languages))
+        else:
+            duckling_load.invoke()
+
         self._is_loaded = True
 
     def parse(self, input_str, language=Language.ENGLISH, dim_filter=None, reference_time=''):

--- a/duckling/duckling.py
+++ b/duckling/duckling.py
@@ -78,7 +78,7 @@ class Duckling(object):
                     jars.append(os.path.join(top, file_name))
         return os.pathsep.join(jars)
 
-    def load(self, languages=None):
+    def load(self, languages=[]):
         """Loads the Duckling corpus.
 
         Languages can be specified, defaults to all.
@@ -88,18 +88,17 @@ class Duckling(object):
                 e.g. [Duckling.ENGLISH, Duckling.FRENCH] or supported ISO 639-1 Codes (e.g. ["en", "fr"])
         """
         duckling_load = self.clojure.var("duckling.core", "load!")
+        clojure_hashmap = self.clojure.var("clojure.core", "hash-map")
+        clojure_list = self.clojure.var("clojure.core", "list")
 
-        if languages is not None:
+        if languages:
             # Duckling's load function expects ISO 639-1 Language Codes (e.g. "en")
-            languages = [Language.convert_to_iso(lang) for lang in languages]
-
-            clojure_hashmap = self.clojure.var("clojure.core", "hash-map")
-            clojure_list = self.clojure.var("clojure.core", "list")
+            iso_languages = [Language.convert_to_iso(lang) for lang in languages]
 
             duckling_load.invoke(
                 clojure_hashmap.invoke(
                     self.clojure.read(':languages'),
-                    clojure_list.invoke(*languages)
+                    clojure_list.invoke(*iso_languages)
                 )
             )
         else:

--- a/duckling/duckling.py
+++ b/duckling/duckling.py
@@ -85,14 +85,23 @@ class Duckling(object):
 
         Args:
             languages: Optional parameter to specify languages,
-                e.g. a list of supported ISO 639-1 Codes (e.g. ["en"])
+                e.g. [Duckling.ENGLISH, Duckling.FRENCH] or supported ISO 639-1 Codes (e.g. ["en", "fr])
         """
         duckling_load = self.clojure.var("duckling.core", "load!")
 
-        # Duckling's load function expects ISO 639-1 Language Codes (e.g. "en")
-        if languages is not None and all(Language.is_supported(lang + "$core") for lang in languages):
-            languages = '{{:languages ("{}")}}'.format('" "'.join(languages))
-            duckling_load.invoke(self.clojure.read(languages))
+        if languages is not None:
+            # Duckling's load function expects ISO 639-1 Language Codes (e.g. "en")
+            languages = [Language.convert_to_iso(lang) for lang in languages]
+
+            clojure_hashmap = self.clojure.var("clojure.core", "hash-map")
+            clojure_list = self.clojure.var("clojure.core", "list")
+
+            duckling_load.invoke(
+                clojure_hashmap.invoke(
+                    self.clojure.read(':languages'),
+                    clojure_list.invoke(*languages)
+                )
+            )
         else:
             duckling_load.invoke()
 

--- a/duckling/language.py
+++ b/duckling/language.py
@@ -61,10 +61,4 @@ class Language(object):
 
     @classmethod
     def convert_to_iso(cls, lang):
-        if lang is not None and cls.is_supported(lang):
-            return lang[:2]
-        elif lang is not None and cls.is_supported(lang + "$core"):   # Support ISO 639-1 Language Codes (e.g. "en")
-            return lang
-        else:
-            raise ValueError("Unsupported language '{}'. Supported languages: {}".format(
-                lang, ", ".join(cls.SUPPORTED_LANGUAGES)))
+        return cls.convert_to_duckling_language_id(lang)[:2]

--- a/duckling/language.py
+++ b/duckling/language.py
@@ -58,3 +58,13 @@ class Language(object):
         else:
             raise ValueError("Unsupported language '{}'. Supported languages: {}".format(
                 lang, ", ".join(cls.SUPPORTED_LANGUAGES)))
+
+    @classmethod
+    def convert_to_iso(cls, lang):
+        if lang is not None and cls.is_supported(lang):
+            return lang[:2]
+        elif lang is not None and cls.is_supported(lang + "$core"):   # Support ISO 639-1 Language Codes (e.g. "en")
+            return lang
+        else:
+            raise ValueError("Unsupported language '{}'. Supported languages: {}".format(
+                lang, ", ".join(cls.SUPPORTED_LANGUAGES)))


### PR DESCRIPTION
Proposed change:
* Add optional argument `languages` to the `load()` function.
* For projects that only work with specific languages, this reduces loading times and memory consumption.
* It is compatible with existing code, because the behaviour does not change when passing no arguments (loads all languages).