### PR TITLE
Prevent value parsing from failing on unknown dimensions

### DIFF
--- a/duckling/duckling.py
+++ b/duckling/duckling.py
@@ -249,7 +249,7 @@ class Duckling(object):
             Dim.PHONENUMBER:    self._parse_string,
             Dim.TIMEZONE:       self._parse_string
         }
-        if not dim:
+        if not dim or dim not in _dims:
             return self._parse_string(java_value)
         try:
             return _dims[dim](java_value)


### PR DESCRIPTION
Not all of the dimensions are part of the `_dims` array. To avoid failure (`KeyError`) unknown dimensions are now just treated as strings.