### PR TITLE
fix java data obj to python obj

### DIFF
--- a/duckling/duckling.py
+++ b/duckling/duckling.py
@@ -12,6 +12,13 @@ from .language import Language
 
 socket.setdefaulttimeout(15)
 
+def _clean_value(java_value):
+    val = str(java_value.toString())
+    if ":" in val:
+        _msg = "[WARN] got value '%s' from java code, this may be an error."
+        print(_msg % val, file=sys.stderr)
+        val = val.split(":")[-1]
+    return val
 
 class Duckling(object):
 
@@ -230,18 +237,10 @@ class Duckling(object):
         return result
 
     def _parse_float(self, java_number):
-        return float(self._clean_value(java_number))
+        return float(_clean_value(java_number))
 
     def _parse_int(self, java_number):
-        return int(self._clean_value(java_number))
-
-    def _clean_value(self, java_value):
-        val = str(java_value.toString())
-        if ":" in val:
-            _msg = "[WARN] got value '%s' from java code, this may be an error."
-            print(_msg % val, file=sys.stderr)
-            val = val.split(":")[-1]
-        return val
+        return int(_clean_value(java_number))
 
     def _parse_value(self, java_value, dim=None):
         _dims = {

--- a/duckling/duckling.py
+++ b/duckling/duckling.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import imp
 import jpype
 import socket
@@ -229,10 +230,18 @@ class Duckling(object):
         return result
 
     def _parse_float(self, java_number):
-        return float(java_number.toString())
+        return float(self._clean_value(java_number))
 
     def _parse_int(self, java_number):
-        return int(java_number.toString())
+        return int(self._clean_value(java_number))
+
+    def _clean_value(self, java_value):
+        val = str(java_value.toString())
+        if ":" in val:
+            _msg = "[WARN] got value '%s' from java code, this may be an error."
+            print(_msg % val, file=sys.stderr)
+            val = val.split(":")[-1]
+        return val
 
     def _parse_value(self, java_value, dim=None):
         _dims = {
@@ -271,7 +280,7 @@ class Duckling(object):
             return self._parse_string(time)
 
     def _parse_string(self, java_string):
-        return java_string
+        return str(java_string)
 
     def _parse_keyword(self, java_keyword, dim=None):
         if dim == Dim.DURATION:
@@ -282,7 +291,7 @@ class Duckling(object):
             return self._parse_string(java_keyword)
 
     def _parse_symbol(self, java_symbol):
-        return java_symbol.toString()[1:]
+        return str(java_symbol.toString())[1:]
 
     def _parse_boolean(self, java_boolean):
-        return bool(strtobool(java_boolean.toString()))
+        return bool(strtobool(str(java_boolean.toString())))

--- a/test.py
+++ b/test.py
@@ -1,0 +1,5 @@
+from duckling import DucklingWrapper
+d = DucklingWrapper()
+d.parse_duration("i am 83 years old")
+
+

--- a/test.py
+++ b/test.py
@@ -1,5 +1,0 @@
-from duckling import DucklingWrapper
-d = DucklingWrapper()
-d.parse_duration("i am 83 years old")
-
-


### PR DESCRIPTION
1.  for better behaviors, Duckling._parse_xxx() functions should return python data object instead of some java data object.  Or will got errors when convert to python int, float or bool, cause these operations need python string operations, like str.lower() and this can not works with java.lang.string.
2. java runtime may return some bad value, e.g. 'Value cannot fit in an int: 2619216000', this may happen when Integer overflows. python int can still work with this big number, so i just add some tricks code for Duckling._parse_int() and Duckling._parse_float(), just get the number value after the ':', and more, add the warning message too.